### PR TITLE
Make logging per-url metrics optional

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -61,6 +61,8 @@ If needed you can overide the default UDP port of 8125 via `define('STATSD_PORT'
 
 If you have a very high traffic site you can lower the default 0.5 sample rate for per-pageload calls via `STATSD_SAMPLE_RATE`.
 
+If you don't want to send metrics per page URL, you can disable this via SKIP_URL_METRICS
+
 Contribute at <a href="https://github.com/uglyrobot/wordpress-statsd">GitHub</a>.
 
 == To Do ==

--- a/statsd.php
+++ b/statsd.php
@@ -246,7 +246,7 @@ class WordPress_StatsD {
 	}
 	
 	public function pre_http($false, $r, $url) {
-		if ( ! is_multisite() ) {
+		if ( ! is_multisite() || defined( 'SKIP_URL_METRICS' ) ) {
 			if ( false !== strpos( parse_url($url, PHP_URL_PATH), 'wp-cron.php' ) ) {
 				$url = 'wp_cron';
 			} else {
@@ -260,7 +260,7 @@ class WordPress_StatsD {
 	}
 	
 	public function post_http($response, $type, $class, $args, $url) {
-		if ( ! is_multisite() ) {
+		if ( ! is_multisite() || defined( 'SKIP_URL_METRICS' ) ) {
 			if ( false !== strpos( parse_url($url, PHP_URL_PATH), 'wp-cron.php' ) ) {
 				$url = 'wp_cron';
 			} else {


### PR DESCRIPTION
Multi-site installations already don't send statistics per URL, to save
graphite from having to create too many metrics. This commit makes this
behavior selectable on non-multi-site installations of wordpress.
